### PR TITLE
Add link to professor's CULPA page in section popup + other js changes

### DIFF
--- a/public/css/application.css
+++ b/public/css/application.css
@@ -181,6 +181,7 @@ div.timeslot_popup div.box tr:last-child td { padding-bottom: 0; }
 .timeslot_popup td a:hover { color: #666; }
 .timeSlotTitle {width: 95%;}
 .timeSlotCallNumber {margin-top: 3px; font-size: .85em; }
+.timeSlotPoints {margin-top: 3px; font-size: .85em; }
 
 #adi-logo {display: block; position: relative; top: 3px;}
 

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -340,8 +340,27 @@ var Calendar = new Class({
         styles: {
           top: String.from(Math.round(start_pixels)) + 'px',
           height: String.from(Math.round(height_pixels)) + 'px' }
-        });
+      });
       wrapper.setProperty( key, val );
+
+      // adjust wrapper height if course info has been clipped
+      wrapper.onmouseover = function(){
+        if ( this.childNodes[0].offsetHeight > this.offsetHeight && !this.expanded ) {
+          this.expanded = true;
+          this.style.height = "";
+
+          // one greater than .remove_link's z-index
+          this.style.zIndex = 6;
+        }
+      }
+      wrapper.onmouseout = function(){
+        if ( this.expanded ) {
+          this.expanded = false;
+          this.style.height = String.from(Math.round(height_pixels)) + 'px';
+          this.style.zIndex = "";
+        }
+      }
+      wrapper.expanded = false;
       return wrapper;
     },
     addSection: function( section ){

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -332,8 +332,8 @@ var Calendar = new Class({
     options: {
       pixels_per_hour: 42,
       calendar_id: 'calendar',
-      start_hour: 9,
-      num_hours: 14,
+      start_hour: 8,
+      num_hours: 16,
       days: [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday" ],
       day_pixel_width: 200
     },

--- a/public/js/application.js
+++ b/public/js/application.js
@@ -94,6 +94,7 @@ var downcaseLong = function(str) {
 };
 
 var data_api_url = "http://courses.adicu.com";
+var culpa_search_url = "http://culpa.info/search/results?search=";
 
 
 /* Extensions */
@@ -203,7 +204,8 @@ var Instructor = new Class({
     this.rank = data.culpa_rank;
     this.link = data.culpa_link;
   },
-  getName: function(){ return ( is_null_or_undefined( this.name ) ) ? 'Unknown' : this.name; }
+  getName: function(){ return ( is_null_or_undefined( this.name ) ) ? 'Unknown' : this.name; },
+  getLink: function(){ return ( is_null_or_undefined( this.link ) ) ? culpa_search_url + encodeURI(this.name) : this.link; }
 });
 
 var Section = new Class({
@@ -551,7 +553,13 @@ var Calendar = new Class({
           daysToAbbreviation( section.getDays() ) + ', ' +
           decimalToTime( section.getStart() ) + "-" +
           decimalToTime( section.getEnd() ) + '</td>'}).inject( table );
-      new Element( 'tr', { 'class': 'instructor', html: '<td>Instructor:</td><td>' + section.getInstructor().getName() + '</td>' }).inject( table );
+      // Add a link to CULPA unless the instructor's name isn't known
+      if ( section.getInstructor().getName() === 'Unknown' ) {
+        new Element( 'tr', { 'class': 'instructor', html: '<td>Instructor:</td><td>' + section.getInstructor().getName() + '</td>' }).inject( table );
+      } else {
+        new Element( 'tr', { 'class': 'instructor', html: '<td>Instructor:</td><td><a href="'
+          + section.getInstructor().getLink() + '" target="_blank">' + section.getInstructor().getName() + '</a></td>' }).inject( table );
+      }
       new Element( 'tr', { 'class': 'location', html: '<td>Location:</td><td>' + section.getLocation() + '</td>' }, this).inject( table );
       new Element( 'tr', { 'class': 'section_description', html: '<td>Description:</td><td>' + section.getDescription() + '</td>' }, this).inject( table );
       new Element( 'tr', { 'class': 'url', html: '<td></td><td>' + '<a target="_blank" href="' + section.getURL() + '">Directory listing</a>' + '</td>'}).inject( table );


### PR DESCRIPTION
The link is only added when possible - if the instructor's name is
unavailable then the popup displays as before (no link to culpa).

Note: The link links to a CULPA search for the professor by
name, and not directly to the professor's page on CULPA. 
This is because of how CULPA does not expose a simple way
to refer directly to a professor's page.

Let me know if anything needs to be changed.

-Lucas
