### PR TITLE
clarify calendar, fix naming & 1 event per class

### DIFF
--- a/public/partials/directives/courseBlock.html
+++ b/public/partials/directives/courseBlock.html
@@ -40,11 +40,16 @@
     readonly="readonly"
     ng-model="pageUrl"
     onclick="this.select();">
+    <p class='share'>
+    Add to
+    <a href="https://support.google.com/calendar/answer/37118?hl=en">GCal</a>
+    /<a href="http://support.apple.com/kb/PH11524">iCal</a>
+    </p>
   <button 
-    class="small gray"
+    class="small blue"
     ng-click="schedule.getCalendar()"
   >
-    Export to iCal
+    Export Calendar
     <i class="fa fa-download"></i>
   </button>
     <span data-tooltip ui-jq="tooltip" ui-options="{placement:'bottom'}" class="has-tip" title="Safari may not support this feature">

--- a/src/js/filters.coffee
+++ b/src/js/filters.coffee
@@ -86,3 +86,13 @@ angular.module("Courses.filters", [])
     titleCaseRegex = /\w\S*/g
     return str.replace titleCaseRegex, (txt) ->
       return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase()
+
+.filter 'calByDay', ->
+  days =
+    0: 'MO',
+    1: 'TU'
+    2: 'WE'
+    3: 'TH'
+    4: 'FR',
+  (input) ->
+    days[input]

--- a/src/js/models/Schedule.coffee
+++ b/src/js/models/Schedule.coffee
@@ -237,12 +237,19 @@ angular.module('Courses.models')
       [wednesday.getMonth(),wednesday.getDate()],
       [thursday.getMonth(),thursday.getDate()],
       [friday.getMonth(),friday.getDate()]]
+
       #create calendar and add events
       calendar = new ICS "adicu.com//Courses"
       for scheduleEvent in @getSelectedSections()
         for subsectionEvent in scheduleEvent.subsections
           startTime = subsectionEvent.startTime.toString().split('.')
           endTime = subsectionEvent.endTime.toString().split('.')
+
+          courseName = $filter('titleCase')(scheduleEvent.title)
+          sectionParent = scheduleEvent.getParentCourse()
+          if sectionParent.displayName != sectionParent.getDefaultDisplayName()
+            courseName = sectionParent.displayName
+
           calendar.addEvent({
             DTSTART: new Date(startDate[2],
               weekDay[subsectionEvent.meetsOn[0]][0],
@@ -254,7 +261,7 @@ angular.module('Courses.models')
               weekDay[subsectionEvent.meetsOn[0]][1],
               parseInt(endTime[0]),
               Math.round(parseFloat("0."+endTime[1])*60),0),
-            SUMMARY: $filter('titleCase')(scheduleEvent.title),
+            SUMMARY: courseName
             LOCATION: subsectionEvent.building+" "+subsectionEvent.room,
             RRULE: "FREQ=WEEKLY;UNTIL="+ICSFormatDate(new Date(endDate[2],endDate[0],endDate[1],11,59,59))
           })

--- a/src/js/models/Schedule.coffee
+++ b/src/js/models/Schedule.coffee
@@ -227,21 +227,13 @@ angular.module('Courses.models')
       endDate[0] -= 1
       #create day of week array based on start date
       weekDayStart = new Date(startDate[2],startDate[0],startDate[1])
-      monday = @getWeekDay(weekDayStart,1)
-      tuesday = @getWeekDay(weekDayStart,2)
-      wednesday = @getWeekDay(weekDayStart,3)
-      thursday = @getWeekDay(weekDayStart,4)
-      friday = @getWeekDay(weekDayStart,5)
-      weekDay = [[monday.getMonth(),monday.getDate()],
-      [tuesday.getMonth(),tuesday.getDate()],
-      [wednesday.getMonth(),wednesday.getDate()],
-      [thursday.getMonth(),thursday.getDate()],
-      [friday.getMonth(),friday.getDate()]]
+      weekday = ([@getWeekDay(weekDayStart, i).getMonth(), @getWeekDay(weekDayStart, i).getDate()] for i in [1..5])
 
       #create calendar and add events
       calendar = new ICS "adicu.com//Courses"
       for scheduleEvent in @getSelectedSections()
         for subsectionEvent in scheduleEvent.subsections
+
           startTime = subsectionEvent.startTime.toString().split('.')
           endTime = subsectionEvent.endTime.toString().split('.')
 
@@ -249,6 +241,10 @@ angular.module('Courses.models')
           sectionParent = scheduleEvent.getParentCourse()
           if sectionParent.displayName != sectionParent.getDefaultDisplayName()
             courseName = sectionParent.displayName
+
+          courseLocation = 'RTBA'
+          if subsectionEvent.building != undefined
+            courseLocation = subsectionEvent.building+" "+subsectionEvent.room
 
           calendar.addEvent({
             DTSTART: new Date(startDate[2],
@@ -262,7 +258,7 @@ angular.module('Courses.models')
               parseInt(endTime[0]),
               Math.round(parseFloat("0."+endTime[1])*60),0),
             SUMMARY: courseName
-            LOCATION: subsectionEvent.building+" "+subsectionEvent.room,
+            LOCATION: courseLocation
             RRULE: "FREQ=WEEKLY;UNTIL="+ICSFormatDate(new Date(endDate[2],endDate[0],endDate[1],11,59,59))
           })
 


### PR DESCRIPTION
Links are to guides on how to add to both gcal and ical.

inputted names are now maintained on the downloaded calendar

now looks like this:
![screenshot 2014-04-11 22 26 50](https://cloud.githubusercontent.com/assets/2801090/2686154/f6a6a9be-c1e9-11e3-875a-61580af16a9b.png)
