### PR TITLE
Fix regex for spaces and explain better

### DIFF
--- a/src/js/models/Course.coffee
+++ b/src/js/models/Course.coffee
@@ -141,7 +141,13 @@ angular.module('Courses.models')
         ejsQuery.should(ejs.QueryStringQuery queryString)
 
       # Match full course (ie COMSW1004)
-      if match = queryString.match /^([A-Z]{4})[A-Z]?(\d{1,4})/i
+      courseRegex = ///
+        ^([A-Z]{4})         # Department ex. (COMS)
+        \s?                 # Possible space in the middle (COMS 1004)
+        [A-Z]{0,2}          # Faculty type (W or BC)
+        (\d{1,4})           # Course numbers
+      ///i                  # Case insensitive
+      if match = queryString.match courseRegex
         department = match[1]
         courseNumber = match[2]
         courseSearch = department + courseNumber + '*'


### PR DESCRIPTION
Closes #166, #167 
Test cases:
![screen shot 2014-04-13 at 19 53 08](https://cloud.githubusercontent.com/assets/920130/2690840/08e87b74-c367-11e3-8d88-36a29128b1da.png)
(The last number case was not addressed because I believe that it's relatively small.)

@natebrennand Can't do that /// regex literal stuff in vanilla JS!
