### PR TITLE
Sizing fixes

### DIFF
--- a/client/stylesheets/app.less
+++ b/client/stylesheets/app.less
@@ -24,3 +24,7 @@ div#app {
   background-color: #29d;
   box-shadow: 0 0 10px #29d, 0 0 5px #29d;
 }
+
+h6 {
+    font-weight: 700;
+}

--- a/client/stylesheets/colors.import.less
+++ b/client/stylesheets/colors.import.less
@@ -75,3 +75,6 @@
 }
 
 @foundation-gray: #d8d8d8;
+@medium-gray: #d0d0d0;
+
+@light-blue: lighten(@blue, 25%);

--- a/client/views/about/about.less
+++ b/client/views/about/about.less
@@ -1,7 +1,14 @@
 @import (reference) "/client/stylesheets/sizes.import.less";
+@import (reference) "/client/stylesheets/colors.import.less";
 
 @media @large {
   .aboutPage {
     height: 52rem;
   }
+}
+
+.aboutPage {
+    a {
+        color: @blue;
+    }
 }

--- a/client/views/layout.less
+++ b/client/views/layout.less
@@ -1,5 +1,15 @@
+@import (reference) "/client/stylesheets/colors.import.less";
+
 nav.top-bar {
   i.fa-facebook {
     margin-right: 0.5em;
   }
+}
+
+.top-bar-section li.active:not(.has-form) a:not(.button) {
+    background-color: @blue;
+
+    &:hover {
+        background-color: @blue-dk;
+    }
 }

--- a/client/views/schedule/schedule.less
+++ b/client/views/schedule/schedule.less
@@ -25,8 +25,10 @@
   }
   .fc-event-title {
     padding: 0.5rem;
+    font-size: 0.8rem;
 
     &:first-line {
+      font-size: 0.9rem;
       font-weight: bold;
     }
   }

--- a/client/views/schedule/schedule.less
+++ b/client/views/schedule/schedule.less
@@ -28,26 +28,23 @@
     font-size: 0.8rem;
 
     &:first-line {
-      font-size: 0.9rem;
       font-weight: bold;
     }
   }
   .fc-event {
     cursor: pointer;
-
-    &:hover {
-      min-height: 50.5px;
-      width: 124.75px !important;
-      z-index: 10000;
-    }
   }
 }
 
 .scheduleSidebar {
   h4, h5 {
-    text-align: center;
-  }
+    padding: 0 0.8rem;
 
+    &.empty {
+      cursor: pointer;
+      color: #888;
+    }
+  }
   ul {
     margin: 0;
   }
@@ -71,19 +68,20 @@
     position: relative;
     text-align: left;
 
-    p, strong {
+    p, h6 {
       color: #FFF;
       display: block;
       margin: 0em;
-      padding: 0 0.8em;
+      padding: 0 0.8rem;
 
       i {
-        margin-left: 0.4em;
+        margin-left: 0.4rem;
       }
 
       &.courseFull {
         padding-top: 0.6rem;
         padding-bottom: 0.2rem;
+        margin-bottom: 0.1rem;
       }
       &.courseTitle{
         padding-bottom: 0.8rem;
@@ -207,18 +205,27 @@
   }
 }
 
-#browser {
+.search-input {
+  margin: 0 !important;
+  &:focus {
+    box-shadow: 0 0 5px rgba(153, 153, 153, .5);
+  }
+}
+
+.results-wrapper {
   position: relative;
-  div.results {
+  .results {
     position: absolute;
     left: 0;
-    top: 50px;
     z-index: 1020;
-    border: 10px solid #75B2DD;
     background: white;
     width: 100%;
-  }
-  .results {
+    box-shadow: 0 0 5px rgba(153, 153, 153, .5);
+    border: 1px solid #999;
+    border-top: 0;
+
+    ul { margin: 0; }
+
     li {
       padding: 10px;
       font-size: 1.1em;
@@ -230,13 +237,18 @@
     li:hover {
       padding: 10px;
       font-size: 1.1em;
-      background: #dddde9;
+      background: @light-blue;
       cursor: pointer;
     }
   }
-  p.course-title {
+  .course-full {
+    display: inline-block;
+    width: 105px;
+  }
+  .course-title {
+    display: block;
+    margin-top: -0.5rem;
     margin-bottom: 0em;
-    font-weight: bold;
     font-size: 0.9em;
   }
 }
@@ -244,3 +256,11 @@
   background: rgba( 255, 255, 255, 0.95);
 }
 
+@media @medium {
+  .results {
+    .course-title {
+      display: inline-block;
+      margin-top: 0;
+    }
+  }
+}

--- a/client/views/schedule/scheduleSidebar.html
+++ b/client/views/schedule/scheduleSidebar.html
@@ -8,9 +8,8 @@
       </h5>
     {{else}}
       <h5
-        class="subheader">
-        <i class="fa fa-2x fa-meh-o"></i>
-        <br/> No Courses. Go add some!
+        class="subheader empty">
+        <br/>Add some courses and they'll appear here!
       </h5>
     {{/if}}
     <dl class="accordion">
@@ -28,9 +27,9 @@
   <dd class="accordionItem accordionItem-{{course.courseFull}}">
     <a href="#" onclick="return false;" data-coursefull="{{course.courseFull}}">
       <div class="courseItem {{getSidebarClasses}}">
-        <strong class="courseFull">
+        <h6 class="courseFull">
           {{course.courseFull}}
-        </strong>
+        </h6>
 
         <p class="courseTitle">
           {{toTitleCase course.courseTitle}}

--- a/client/views/schedule/scheduleSidebar.js
+++ b/client/views/schedule/scheduleSidebar.js
@@ -48,6 +48,12 @@ Template.scheduleSidebar.events({
     var item = e.currentTarget;
     var courseFull = $(item).data('coursefull');
     return Template.scheduleSidebar.toggleAccordion(courseFull);
+  },
+  'click .empty': function(e) {
+    var input = $('.search-input');
+    if(input){
+      input.focus();
+    }
   }
 });
 

--- a/client/views/schedule/scheduleView.html
+++ b/client/views/schedule/scheduleView.html
@@ -37,7 +37,7 @@
       class="custom"
       onkeypress="return event.keyCode != 13;">
       <div class="row">
-        <div class="medium-3 columns">
+        <div class="medium-4 large-3 columns">
           <div class="row collapse">
             {{#each semesters}}
               <div
@@ -47,7 +47,7 @@
             {{/each}}
           </div>
         </div>
-        <div class="medium-9 columns">
+        <div class="medium-8 large-9 columns">
           <input
             type="text"
             id="searchInput"

--- a/client/views/schedule/scheduleView.html
+++ b/client/views/schedule/scheduleView.html
@@ -49,36 +49,41 @@
         </div>
         <div class="medium-8 large-9 columns">
           <input
+            class="search-input"
             type="text"
             id="searchInput"
             name="search_input"
             onsubmit="return false;"
             placeholder="Type a course title or call number to begin. Ex. COMS1004 or 71229"
           />
+          {{#if searchResults}}
+            <div class="results-wrapper">
+              <div class="results">
+                <ul class="no-bullet">
+                  {{#each searchResults}}
+                  {{#with
+                    result=.
+                    schedule=../schedule
+                  }}
+                    <li class="courseResultItem">
+                      <h6 class="course-full">
+                        {{result.CourseFull}}
+                      </h6>
+                      <p class="course-title">
+                        {{toTitleCase result.CourseTitle}}
+                      </p>
+                      <p class="description">
+                        {{result.Description}}
+                      </p>
+                    </li>
+                  {{/with}}
+                  {{/each}}
+                </ul>
+              </div>
+            </div>
+          {{/if}}
         </div>
       </div>
     </form>
   </div>
-
-  {{#if searchResults}}
-    <div class="results">
-      <ul class="no-bullet">
-        {{#each searchResults}}
-        {{#with
-          result=.
-          schedule=../schedule
-        }}
-          <li class="courseResultItem">
-            <p class="course-title">
-              {{result.CourseFull}}: {{result.CourseTitle}}
-            </p>
-            <p class="description">
-              {{result.Description}}
-            </p>
-          </li>
-        {{/with}}
-        {{/each}}
-      </ul>
-    </div>
-  {{/if}}
 </template>


### PR DESCRIPTION
A bunch of small visual tweaks:
- Text in weekview is slightly smaller
- Search box is only 75% width, and shares similar styling to the search box
- Search items hovers to blue
- Search items are not all bold anymore
- Move to consistent blues across stylesheets
- New "No courses" stylesheet that is actually a link that if clicked focuses on the searchbox.  Also has different text to be more descriptive of what this area is

![screen shot 2014-07-30 at 2 39 00 am](https://cloud.githubusercontent.com/assets/2433509/3745906/516da94e-17b5-11e4-931c-e6946b50b7e7.png)
![screen shot 2014-07-30 at 2 37 50 am](https://cloud.githubusercontent.com/assets/2433509/3745907/516de256-17b5-11e4-865d-7d6c71103741.png)
