### PR TITLE
Add ability to navigate serach results with keyboard

### DIFF
--- a/client/views/schedule/schedule.less
+++ b/client/views/schedule/schedule.less
@@ -233,12 +233,16 @@
         font-size: 0.8em;
         margin-bottom: 0em;
       }
-    }
-    li:hover {
-      padding: 10px;
-      font-size: 1.1em;
-      background: @light-blue;
-      cursor: pointer;
+
+      &.selected, &.selected:hover {
+        background-color: @light-blue;
+      }
+      &:hover {
+        padding: 10px;
+        font-size: 1.1em;
+        background: @foundation-gray;
+        cursor: pointer;
+      }
     }
   }
   .course-full {

--- a/client/views/schedule/scheduleView.html
+++ b/client/views/schedule/scheduleView.html
@@ -65,7 +65,8 @@
                     result=.
                     schedule=../schedule
                   }}
-                    <li class="courseResultItem">
+                    <li class="courseResultItem"
+                        data-course-full="{{result.CourseFull}}">
                       <h6 class="course-full">
                         {{result.CourseFull}}
                       </h6>

--- a/client/views/schedule/scheduleView.js
+++ b/client/views/schedule/scheduleView.js
@@ -144,6 +144,13 @@ Template.scheduleSearchArea.rendered = function() {
     e.preventDefault();
   };
 
+  var clickHandler = function(e) {
+    /**
+     * Clicking back into the search box to edit a query should not clear it
+     */
+    e.stopPropagation();
+  };
+
   Deps.autorun(function() {
     results = Session.get('coursesSearchResults');
 
@@ -161,13 +168,15 @@ Template.scheduleSearchArea.rendered = function() {
       // or 'blur's the input)
       $(document).bind('keydown', keydownHandler);
       $(document).bind('click', resetSearch);
-      $('.search input').bind('blur', resetSearch);
+      $('.search-input').bind('click', clickHandler);
+      $('.search-input').bind('blur', resetSearch);
 
     } else {
       // The search results are not being shown, unbind keydown, click, and blur
       $(document).unbind('keydown', keydownHandler);
       $(document).unbind('click', resetSearch);
-      $('.search input').unbind('blur', resetSearch);
+      $('.search-input').unbind('click', clickHandler);
+      $('.search-input').unbind('blur', resetSearch);
     }
   });
 };

--- a/client/views/schedule/scheduleView.js
+++ b/client/views/schedule/scheduleView.js
@@ -12,8 +12,6 @@ Template.scheduleView.shouldShowSearch = function() {
   }
 };
 
-
-
 Template.scheduleSearchArea.semesterClasses = function() {
   var selectedSemester = String(this);
   var currentSemester = Session.get('currentSemester');
@@ -36,7 +34,7 @@ var dirtyGetSchedule = function() {
   if (currentRouter.params._id) {
     return Schedules.findOne(currentRouter.params._id);
   }
-}
+};
 
 var createOrGetSchedule = function() {
   var semester = Session.get('currentSemester');
@@ -53,6 +51,125 @@ var createOrGetSchedule = function() {
   } else {
     return handleError(new Error('No user!'));
   }
+};
+
+
+
+// Runs automatically when template is rendered
+Template.scheduleSearchArea.rendered = function() {
+  var results;
+
+  var currentIndex = function() {
+    /**
+     * Return the index of the selected search result in the list of course
+     * search results, or 0 if none are selected. It has the `selected` class.
+     */
+
+    var selectedResult = $('.courseResultItem.selected');
+    if (!selectedResult) { return 0; }
+
+    var selectedCourseFull = selectedResult.data('course-full');
+    var selectedIndex = results.map(function(r) {return r.CourseFull; })
+                               .indexOf(selectedCourseFull);
+    if (selectedIndex === -1) { return 0; }
+    return selectedIndex;
+  };
+
+  var selectResultAtIndex = function(index) {
+    /**
+     * Deselect the currently selected search result, and select the result at
+     * `index`.
+     */
+    $('.courseResultItem.selected').removeClass('selected');
+    courseFull = results[index].CourseFull;
+    $('.courseResultItem[data-course-full="' + courseFull +'"]').addClass('selected');
+  };
+
+  var up = function() {
+    /**
+     * Select the search result above, if there is one.
+     */
+    var idx = currentIndex();
+    if (idx > 0) {
+      selectResultAtIndex(idx - 1);
+    }
+  };
+
+  var down = function() {
+    /**
+     * Select the search result below, if there is one.
+     */
+    var idx = currentIndex();
+    if (idx + 1 < results.length){
+      selectResultAtIndex(idx + 1);
+    }
+  };
+
+  var keydownHandler = function(e) {
+    /**
+     * Handle keypresses while the search results are displayed like so:
+     *  - tab / shift+tab cycle up and down the results list
+     *  - up / down do the same
+     *  - enter adds the selected class
+     *  - esc clears the search
+     */
+    switch(e.which) {
+      case 9: //tab, shift+tab
+      if (e.shiftKey) {
+        up();
+      } else {
+        down();
+      }
+      break;
+
+      case 13: //enter
+      $('.courseResultItem.selected').click();
+      break;
+
+      case 27: //escape
+      resetSearch();
+      break;
+
+      case 38: //up
+      up();
+      break;
+
+      case 40: //down
+      down();
+      break;
+
+      default:
+      return;
+    }
+    e.preventDefault();
+  };
+
+  Deps.autorun(function() {
+    results = Session.get('coursesSearchResults');
+
+    if (results.length > 0) {
+      // The results exist, but the DOM elements don't exist yet. Wait until
+      // they do, and then select the first one.
+      var checkExist = setInterval(function() {
+         if ($('.courseResultItem').length) {
+            clearInterval(checkExist);
+            selectResultAtIndex(0);
+         }
+      }, 50);
+
+      // bind keydown and click outside to reset, or press ESC (which defocuses
+      // or 'blur's the input)
+      $(document).bind('keydown', keydownHandler);
+      $(document).bind('click', resetSearch);
+      $('.search input').bind('blur', resetSearch);
+
+    } else {
+      // The search results are not being shown, unbind keydown, click, and blur
+      $(document).unbind('keydown', keydownHandler);
+      $(document).unbind('click', resetSearch);
+      $('.search input').unbind('blur', resetSearch);
+    }
+  });
 };
 
 var searchTimeout;

--- a/client/views/schedule/scheduleView.js
+++ b/client/views/schedule/scheduleView.js
@@ -66,12 +66,16 @@ Template.scheduleSearchArea.rendered = function() {
      */
 
     var selectedResult = $('.courseResultItem.selected');
-    if (!selectedResult) { return 0; }
+    if (!selectedResult) {
+      return 0;
+    }
 
     var selectedCourseFull = selectedResult.data('course-full');
     var selectedIndex = results.map(function(r) {return r.CourseFull; })
                                .indexOf(selectedCourseFull);
-    if (selectedIndex === -1) { return 0; }
+    if (selectedIndex === -1) {
+      return 0;
+    }
     return selectedIndex;
   };
 
@@ -169,14 +173,12 @@ Template.scheduleSearchArea.rendered = function() {
       $(document).bind('keydown', keydownHandler);
       $(document).bind('click', resetSearch);
       $('.search-input').bind('click', clickHandler);
-      $('.search-input').bind('blur', resetSearch);
 
     } else {
       // The search results are not being shown, unbind keydown, click, and blur
       $(document).unbind('keydown', keydownHandler);
       $(document).unbind('click', resetSearch);
       $('.search-input').unbind('click', clickHandler);
-      $('.search-input').unbind('blur', resetSearch);
     }
   });
 };
@@ -192,6 +194,7 @@ Template.scheduleSearchArea.events({
     Router.go('scheduleView');
   },
   'click .courseResultItem': function(e) {
+    e.stopPropagation();
     var that = this;
     var schedule = createOrGetSchedule.call(this);
     schedule.addCourse(this.result.CourseFull, function(err) {

--- a/collections/Sections.js
+++ b/collections/Sections.js
@@ -96,7 +96,6 @@ Sections.helpers({
     if (!this.getParentCourse)
       return;
     var location = "";
-    console.log(this);
     if (!this.building[0]) {
       location = "Location TBA";
     } else if (!this.room[0]) {


### PR DESCRIPTION
This allows you to:
- navigate up and down the list of results with UP/DOWN, or TAB / SHIFT+TAB
- add the selected class by pressing the ENTER key
- clear search with the ESC key
- clear search by clicking outside the search results
- continue to use the mouse as expected, including adding classes and clicking into the search box to edit queries

Selected result (which will be added if ENTER is clicked) is shown in blue, and defaults to the first element.  Elements also turn gray on hover, and can be clicked to be added.  (this mirrors the Google Chrome omnibar search behavior)

![screen shot 2014-07-31 at 1 31 20 am](https://cloud.githubusercontent.com/assets/2433509/3760269/f01dc10a-1873-11e4-9711-9ef0419d430b.png)

Closes #197 
