### PR TITLE
Fix homescreen loading. Closes #229

### DIFF
--- a/client/lib/router.js
+++ b/client/lib/router.js
@@ -16,7 +16,7 @@ Router.onBeforeAction('loading');
 Router.map(function() {
   this.route('home', {
     path: '/',
-    onBeforeAction: function() {
+    onAfterAction: function() {
       // Redirect to schedule by default
       Co.smartRedirect.call(this, 'scheduleView');
     },


### PR DESCRIPTION
Also closes #222 

Looks like something changed with IronRouter internals to not allow redirects while in `onBeforeAction`. Change to use `onAfterAction` to do redirect after the page loads instead of before. This shouldn't be a big problem.
