### PR TITLE
Fix weird redirect behavior

### DIFF
--- a/client/lib/router.js
+++ b/client/lib/router.js
@@ -21,7 +21,7 @@ Router.map(function() {
       Co.smartRedirect.call(this, 'scheduleView');
     },
     unload: function() {
-      Session.set('routerPrevPath', this.path);
+      Co.routerPrevPath = this.path;
     }
   });
 

--- a/client/views/home.html
+++ b/client/views/home.html
@@ -1,0 +1,3 @@
+<template name="home">
+If you're looking for your schedule, <a href="/schedule">click here</a>.
+</template>

--- a/client/views/schedule/ScheduleViewController.js
+++ b/client/views/schedule/ScheduleViewController.js
@@ -11,6 +11,7 @@ ScheduleViewController = RouteController.extend({
   onStop: function() {
     // Clear search results when leaving page
     Session.set('coursesSearchResults', []);
+    Co.routerPrevPath = this.path;
   },
 
   onData: function() {
@@ -32,10 +33,6 @@ ScheduleViewController = RouteController.extend({
       // ID parameter, but no matching schedule exists
       Co.smartRedirect.call(this, 'scheduleView');
     }
-  },
-
-  unload: function() {
-    Session.set('routerPrevPath', this.path);
   },
 
   waitOn: function() {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -105,7 +105,7 @@ Co.smartRedirect = function(routeName, parameters) {
   // routerPrevPath must be set in Session
   // Make sure to bind this correctly when calling
 
-  var prevPath = Session.get('routerPrevPath');
+  var prevPath = Co.routerPrevPath;
   var requestedPath =
     this.router.routes[routeName].path(parameters);
   if (prevPath && prevPath === requestedPath) {


### PR DESCRIPTION
It turns out that you're not supposed to use a reactive source aka `Session.set`/`Session.get` in routing code. I was using that before, which was causing the redirect function to fail silently if I used the `Session` line.

Should be able to go back from `/schedule` to `/` now as well as be redirected properly from `/` to `/schedule`

Closes #229 
